### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "remotion-director",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Marketplace for remotion-director — the 甲乙环 (critic-loop) motion-design pipeline plugin.",
   "owner": {
     "name": "Zane"
@@ -10,7 +10,7 @@
     {
       "name": "remotion-director",
       "description": "Design and build a finished motion piece (vertical 1080×1920 by default; landscape/square supported) from a brief through the 甲乙环 (critic-loop) pipeline: a unified design+build agent (乙) drafts the design and writes the Remotion code in one continuous context; N independent draws are blind-selected for the most promising base; a design-blind aesthetic critic (甲) judges only the rendered frames, round after round until it converges; a fresh-context tempo pass then re-times the result; the user's own eyes are the final gate.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Zane"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remotion-director",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Design and build a finished motion piece (vertical 1080×1920 by default; landscape/square supported) from a brief through the 甲乙环 (critic-loop) pipeline: a unified design+build agent (乙) drafts a design and writes the Remotion code in one continuous context; N independent draws are blind-selected for the most promising base; a design-blind aesthetic critic (甲) judges only the rendered frames, round after round until it converges; a fresh-context tempo pass then re-times the result, covering the time axis a frame-judged loop cannot see; the user's own eyes are the final gate. Equipment, not constraints — the engine is unleashed.",
   "author": {
     "name": "Zane"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remotion-director",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "MIT",
   "description": "Remotion engine + render harnesses for the remotion-director 甲乙环 pipeline. The design knowledge lives in skills/; this package provides the engine deps and the render/strip tooling.",


### PR DESCRIPTION
Version bump for the 0.2.0 release (Step 4.5 tempo pass, merged in #1).

Bumps `plugin.json`, both version fields in `marketplace.json`, and the engine `package.json` from 0.1.0 → 0.2.0. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)