### PR TITLE
docs(readme): promo click-through now plays in-browser (jsDelivr links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ https://github.com/user-attachments/assets/f34c4aef-fd88-44be-9300-b2a5418fdfe1
 
 <table>
   <tr>
-    <td><a href="https://github.com/Zane-0x5a/remotion-director/blob/master/docs/assets/promos/promo-kimi-k3.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-kimi-k3-thumb.webp" width="430" alt="Promo created by Kimi K3 — click to play the full piece"></a></td>
-    <td><a href="https://github.com/Zane-0x5a/remotion-director/blob/master/docs/assets/promos/promo-claude-opus-5.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-claude-opus-5-thumb.webp" width="430" alt="Promo created by Claude Opus 5 — click to play the full piece"></a></td>
+    <td><a href="https://cdn.jsdelivr.net/gh/Zane-0x5a/remotion-director@master/docs/assets/promos/promo-kimi-k3.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-kimi-k3-thumb.webp" width="430" alt="Promo created by Kimi K3 — click to play the full piece"></a></td>
+    <td><a href="https://cdn.jsdelivr.net/gh/Zane-0x5a/remotion-director@master/docs/assets/promos/promo-claude-opus-5.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-claude-opus-5-thumb.webp" width="430" alt="Promo created by Claude Opus 5 — click to play the full piece"></a></td>
   </tr>
   <tr>
     <td align="center"><sub>Created by <b>Kimi K3</b></sub></td>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,8 +18,8 @@ https://github.com/user-attachments/assets/1243ab0f-cb37-4a83-90d4-62b2a56688ba
 
 <table>
   <tr>
-    <td><a href="https://github.com/Zane-0x5a/remotion-director/blob/master/docs/assets/promos/promo-kimi-k3.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-kimi-k3-thumb.webp" width="430" alt="由 Kimi K3 创作的宣发片——点击播放完整影片"></a></td>
-    <td><a href="https://github.com/Zane-0x5a/remotion-director/blob/master/docs/assets/promos/promo-claude-opus-5.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-claude-opus-5-thumb.webp" width="430" alt="由 Claude Opus 5 创作的宣发片——点击播放完整影片"></a></td>
+    <td><a href="https://cdn.jsdelivr.net/gh/Zane-0x5a/remotion-director@master/docs/assets/promos/promo-kimi-k3.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-kimi-k3-thumb.webp" width="430" alt="由 Kimi K3 创作的宣发片——点击播放完整影片"></a></td>
+    <td><a href="https://cdn.jsdelivr.net/gh/Zane-0x5a/remotion-director@master/docs/assets/promos/promo-claude-opus-5.mp4"><img src="https://raw.githubusercontent.com/Zane-0x5a/remotion-director/master/docs/assets/promos/promo-claude-opus-5-thumb.webp" width="430" alt="由 Claude Opus 5 创作的宣发片——点击播放完整影片"></a></td>
   </tr>
   <tr>
     <td align="center"><sub>由 <b>Kimi K3</b> 创作</sub></td>


### PR DESCRIPTION
## Problem

After PR #4, clicking a promo thumbnail lands on the mp4's **blob page**, which shows only *"View raw … we can't show files that are this big"*. Verified empirically: a **7 KB** mp4 gets the identical treatment — GitHub's file browser never renders a video player for committed files, at any size (so compressing the videos wouldn't help, it would only degrade them). The raw URL serves `application/octet-stream` → browser download, not playback.

## Fix

Thumbnails now link to the **jsDelivr CDN** URL of the same repo files (`cdn.jsdelivr.net/gh/Zane-0x5a/remotion-director@master/...`), verified to serve `video/mp4` — navigating plays the full piece directly in the browser, full quality, no repo settings changed. Thumbnails and captions untouched.

The user-attachments upgrade (true inline `<video>` players on the README itself, like the hero) remains available as a follow-up — it needs a 2-minute manual drag-drop of the two mp4s into any issue/PR composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)