### PR TITLE
feat(check-env): --fix self-repairs engine-dep drift in existing workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ This is a Claude Code plugin. Install it directly from this GitHub repo — no m
   (`-g` = global; a project-local install under your workspace's `.agents/skills` / `.claude/skills` is also detected by `check-env`.)
 - **Engine dependencies** (Remotion 4.0.515 — pinned exactly — + three + tooling) — installed per-piece into your workspace by the `create` skill's scaffold step (a single `npm install`).
 
+> **In a real run you don't have to do any of this by hand.** Step 0 checks the environment and repairs engine-dep drift itself (`--fix`); for the remaining items (the skill, ffmpeg) the agent **offers to run the install for you and asks only for one confirmation**, since those write outside your project. The commands above are for setting up ahead of time.
+
 You can run the environment check yourself anytime:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <your-project-dir>

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ You can run the environment check yourself anytime:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <your-project-dir>
 ```
+If it reports engine-dep drift (e.g. a workspace created by an older release), `--fix` repairs it deterministically — merging the pinned deps into the workspace `package.json` (your own entries are preserved) and running `npm install`:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <your-project-dir> --fix
+```
 
 ## Usage
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,6 +124,10 @@ remotion-director 就是围绕这个赌注造出来的、能跑的管线。你�
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <你的项目目录>
 ```
+若它报出引擎依赖漂移(比如旧版本插件创建的 workspace),`--fix` 会确定性地修复——把锁定的依赖合并进 workspace 的 `package.json`(保留你自己的条目)并执行 `npm install`:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <你的项目目录> --fix
+```
 
 ## 用法
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -120,6 +120,8 @@ remotion-director 就是围绕这个赌注造出来的、能跑的管线。你�
   (`-g` 为全局安装;装在你 workspace 下的 `.agents/skills` / `.claude/skills` 项目级副本同样会被 `check-env` 探测到。)
 - **引擎依赖**(Remotion 4.0.515——精确锁定——+ three + 工具链)——由 `create` skill 的脚手架步逐片装进你的 workspace(一次 `npm install`)。
 
+> **真实运行时,以上这些都不需要你动手。** Step 0 会检查环境并自行修复引擎依赖漂移(`--fix`);剩下的项(技能、ffmpeg)agent 会**主动提出替你安装,只向你请求一次确认**(因为它们要写到你的项目目录之外)。上面的命令仅供你想提前装好时使用。
+
 你也可以随时自己跑环境检查:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <你的项目目录>

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -49,7 +49,9 @@ It checks three things and tells you exactly what to do for any that are missing
 > ```bash
 > node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <the-workspace> --fix
 > ```
-> `--fix` merges the plugin's pinned dependency blocks into the workspace `package.json` (the user's own entries are preserved — only pinned keys are set) and runs `npm install`, then the same run re-verifies. Do NOT hand this mechanical step to the user, and do NOT freelance a different repair (e.g. `npm install remotion@latest` — that breaks the pin). Skill/ffmpeg gaps are the only items that may require the user (host-level installs).
+> `--fix` merges the plugin's pinned dependency blocks into the workspace `package.json` (the user's own entries are preserved — only pinned keys are set) and runs `npm install`, then the same run re-verifies. Do NOT hand this mechanical step to the user, and do NOT freelance a different repair (e.g. `npm install remotion@latest` — that breaks the pin).
+>
+> **Same rule for host-level installs, with one caveat.** Skill missing/old-form and ffmpeg missing aren't "the user's problem" either — **offer to install them yourself and run the install** (`npx skills add remotion-dev/skills -g`; `winget install Gyan.FFmpeg` / `brew install ffmpeg` / `apt install ffmpeg`). The caveat: these write outside the workspace (a global skill dir, the system PATH), so get the user's **one confirmation first** — that's all the user is ever needed for here: consent, not labor.
 
 ## Step 0.5 — Commission (gate; collect before any draw)
 

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -45,6 +45,12 @@ It checks three things and tells you exactly what to do for any that are missing
 
 **Gate**: engine deps resolve at the pinned version, RBP is reachable in router form (skill–engine version drift is surfaced as a warning to act on, not silently ignored), ffmpeg is present.
 
+> **Repairing the engine gate is YOUR job, never the user's.** If check-env reports missing deps or version drift — the classic case is a workspace created by an older plugin release — repair it in place, deterministically:
+> ```bash
+> node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <the-workspace> --fix
+> ```
+> `--fix` merges the plugin's pinned dependency blocks into the workspace `package.json` (the user's own entries are preserved — only pinned keys are set) and runs `npm install`, then the same run re-verifies. Do NOT hand this mechanical step to the user, and do NOT freelance a different repair (e.g. `npm install remotion@latest` — that breaks the pin). Skill/ffmpeg gaps are the only items that may require the user (host-level installs).
+
 ## Step 0.5 — Commission (gate; collect before any draw)
 
 A real run starts from the user, not from a guess. **Before scaffolding or drawing, confirm the commission** — the brief, the spec, and the production knobs from `Inputs`. Do not start drawing until this is settled.

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -45,6 +45,8 @@ It checks three things and tells you exactly what to do for any that are missing
 
 **Gate**: engine deps resolve at the pinned version, RBP is reachable in router form (skill–engine version drift is surfaced as a warning to act on, not silently ignored), ffmpeg is present.
 
+(On a **first run against a fresh workspace** the engine-deps item is missing by definition — that's not a blocker to escalate, it's Step 1's job: scaffold, or `--fix` right away, then re-run until green. The gate must be green before any draw.)
+
 > **Repairing the engine gate is YOUR job, never the user's.** If check-env reports missing deps or version drift — the classic case is a workspace created by an older plugin release — repair it in place, deterministically:
 > ```bash
 > node "${CLAUDE_PLUGIN_ROOT}/tools/check-env.mjs" --workspace <the-workspace> --fix

--- a/tools/check-env.mjs
+++ b/tools/check-env.mjs
@@ -170,6 +170,8 @@ if (!rbp) {
   hint(`    npx skills add remotion-dev/skills -g`);
   hint(`  (-g = global; a project-local install under <workspace>/.agents|claude/skills is also`);
   hint(`   detected. Or use the host's skill-install flow.) The builder reads it for the live surface.`);
+  hint(`  orchestrator: offer to RUN this install yourself — it writes outside the workspace,`);
+  hint(`  so get the user's one confirmation first. Consent, not labor.`);
   problems++;
 } else {
   // Since the 2026-07 upstream restructure the skill is a ROUTER whose frontmatter
@@ -188,6 +190,7 @@ if (!rbp) {
     hint(`instructions navigate the router. Update:  npx skills update remotion-best-practices -g`);
     hint(`(if that claims the skill "was deleted upstream", remove ${rbp}`);
     hint(`and re-run:  npx skills add remotion-dev/skills -g)`);
+    hint(`orchestrator: you can run either command yourself — confirm with the user first.`);
     problems++;
   } else {
     const skillVersion = m[1];
@@ -234,6 +237,8 @@ if (ff) {
   hint(`without it, render-strip silently degrades to UNIFORM sampling (no held/mid roles) —`);
   hint(`the critic loop then loses the validated frame-selection. Do NOT run the pipeline until ffmpeg is installed.`);
   hint(`  Windows: winget install Gyan.FFmpeg   |   macOS: brew install ffmpeg   |   Linux: apt install ffmpeg`);
+  hint(`  orchestrator: offer to RUN the install yourself — it writes to the system PATH,`);
+  hint(`  so get the user's one confirmation first. Consent, not labor.`);
   problems++;
 }
 

--- a/tools/check-env.mjs
+++ b/tools/check-env.mjs
@@ -20,13 +20,19 @@
  *                         a degraded, non-validated regime. Treated as a hard prerequisite.
  *
  * Usage:
- *   node tools/check-env.mjs [--workspace <dir>]
+ *   node tools/check-env.mjs [--workspace <dir>] [--fix]
  *     --workspace <dir>  where the user's piece + its npm install live (default: cwd)
+ *     --fix              repair engine-dep drift IN THE WORKSPACE before checking:
+ *                        merges the plugin's pinned dependency blocks into the
+ *                        workspace package.json (the user's own entries are
+ *                        preserved — only pinned keys are set) and runs npm install.
+ *                        Deterministic self-repair: never hand this mechanical
+ *                        step to the user.
  *
  * Exit code 0 if everything required is present; 1 if anything is missing.
  */
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
@@ -71,10 +77,42 @@ const REQUIRED_DEPS = [
 ];
 const wsModules = join(workspace, "node_modules");
 let engineVersion = null;
+
+// ── 0. --fix: deterministic repair of engine-dep drift, before checking ─────
+// Merges the plugin's pinned dependency blocks INTO the workspace package.json
+// (the user's own entries are preserved — only pinned keys are set), then runs
+// npm install. The checks below then verify the result like any other run.
+if (args.includes("--fix")) {
+  const wsPkgPath = join(workspace, "package.json");
+  let wsPkg = null;
+  try {
+    wsPkg = JSON.parse(readFileSync(wsPkgPath, "utf8"));
+  } catch { /* missing or corrupt */ }
+  if (!wsPkg || typeof wsPkg !== "object") {
+    wsPkg = { name: basename(workspace), private: true };
+    warn(`--fix: no readable package.json in workspace — scaffolding a minimal one`);
+  }
+  wsPkg.dependencies = { ...(wsPkg.dependencies ?? {}), ...pluginPkg.dependencies };
+  wsPkg.devDependencies = { ...(wsPkg.devDependencies ?? {}), ...pluginPkg.devDependencies };
+  writeFileSync(wsPkgPath, JSON.stringify(wsPkg, null, 2) + "\n");
+  warn(`--fix: workspace package.json merged to the pinned set (remotion ${PINNED_ENGINE}); running npm install ...`);
+  const inst = spawnSync("npm", ["install"], {
+    cwd: workspace,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (inst.status !== 0) {
+    bad(`--fix: npm install failed (see output above)`);
+    process.exit(1);
+  }
+  console.log("");
+}
+
 if (!existsSync(wsModules)) {
   bad(`engine deps: no node_modules in workspace`);
   hint(`scaffold a package.json (copy ${join(PLUGIN_ROOT, "package.json")}'s deps) and run:  npm install`);
-  hint(`(the create skill's Step 1 does this for you)`);
+  hint(`(the create skill's Step 1 does this for you) — or let this checker repair it:`);
+  hint(`    node "${join(PLUGIN_ROOT, "tools", "check-env.mjs")}" --workspace <dir> --fix`);
   problems++;
 } else {
   const missing = REQUIRED_DEPS.filter((d) => !existsSync(join(wsModules, ...d.split("/"))));
@@ -101,7 +139,8 @@ if (!existsSync(wsModules)) {
   } else {
     bad(`engine version drift vs pin ${PINNED_ENGINE} — ${drift.join(", ")}`);
     hint(`the pipeline validates ONE engine version at a time (pinned exactly in the plugin's package.json).`);
-    hint(`re-copy the plugin package.json's dependency block into the workspace and re-run npm install.`);
+    hint(`repair it deterministically (merges pinned deps, keeps the user's own, runs npm install):`);
+    hint(`    node "${join(PLUGIN_ROOT, "tools", "check-env.mjs")}" --workspace <dir> --fix`);
     problems++;
   }
 }


### PR DESCRIPTION
## Why

v0.3.0's version gate made a workspace created by an older release fail `check-env` — but the repair ("re-copy the pinned dependency block, re-run `npm install`") was documented as a **manual user step** (the v0.3.0 release notes even instruct it). That's wrong on two counts: the orchestrator is an agent that can and should do mechanical work itself, and "overwrite the dependency block" is a clobber risk for workspaces where the user added their own deps — merging needs a judgment call that shouldn't be freelanced per-run.

## What changes

- **`check-env.mjs --fix`**: before checking, deterministically repairs engine-dep drift in the workspace — merges the plugin's pinned `dependencies`/`devDependencies` blocks into the workspace `package.json` (**only pinned keys are set; the user's own entries are preserved**), runs `npm install`, then the same run re-verifies everything (deps present, all pinned remotion packages at the pin, skill pairing, ffmpeg).
- **Failure hints** for missing deps and version drift now point at `--fix`.
- **`create/SKILL.md` Step 0**: repairing the engine gate is explicitly the orchestrator's job, never the user's — with `--fix` as the sanctioned path and an explicit ban on freelancing a different repair (e.g. `npm install remotion@latest`, which breaks the pin). Skill/ffmpeg gaps get the same treatment: the orchestrator offers and runs the install itself (`npx skills add remotion-dev/skills -g`, winget/brew/apt ffmpeg) — the user is only ever asked for one confirmation, since these write outside the workspace. Consent, not labor.
- **READMEs**: document `--fix` for manual use.

## Validation

Synthetic drifted workspace (`remotion@4.0.477` + a user-owned dep, no `node_modules`): one `--fix` run merged the pinned set (user dep intact), installed, and closed green — `engine version matches pin (4.0.515, all 11 remotion packages)`.

## Note

This is the robustness follow-up to the v0.3.0 upgrade path: after this lands, "existing workspace from an older release" is self-healing in the pipeline instead of a documented manual step. Worth cutting as v0.3.1.



## Sweep: no remaining user-chores

A follow-up sweep for every place that still handed labor to the user found three, all fixed here: check-env's skill/ffmpeg hints now address the orchestrator directly (offer to run the install; one confirmation, consent-not-labor); create Step 0 explicitly exempts the fresh-workspace case (engine deps are missing by definition before Step 1 — don't escalate, fix); and both READMEs tell users none of the prerequisites are manual chores in a real run. What is deliberately left to the user, by design: the brief/commission decisions, the N knob, duration authority, the tempo-blocked call, and the Step 5 eyeball gate — judgment stays human, labor doesn't.
